### PR TITLE
Fix typo in CMakeLists.txt (ref issue #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,12 @@ option(coverage "Use coverage flag" OFF)
 set(CMAKE_CXX_FLAGS "-std=c++0x -Wall")
 
 if (debug)
-     set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
      if (coverage)
           set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
      endif()
 else ()
-     set(CMAKE_C_FLAGS "-Wall -O2")
+     set(CMAKE_CXX_FLAGS "-Wall -O2")
 endif()
 
 


### PR DESCRIPTION
Typo had the flags set to `CMAKE_C_FLAGS`, and not to `CMAKE_CXX_FLAGS`.