### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: cpp
 compiler: gcc
-dist: trusty
+dist: xenial
 notifications:
   email: false
+
+addons:
+  apt:
+    packages: lcov
 
 before_install:
   # C++17
@@ -14,12 +18,6 @@ install:
   - sudo apt-get install -qq g++-7
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
   - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 90
-   
-  # install newer LCOV (apt version outdated and fails for new gcov).
-  - wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
-  - tar xf lcov_1.11.orig.tar.gz
-  - sudo make -C lcov-1.11/ install  
-  - which lcov 
 
   # Install coverals gem for uploading coverage to coveralls.
   - gem install coveralls-lcov
@@ -35,7 +33,6 @@ script:
   - cd $PARENTDIR/build
   - cmake -DCMAKE_BUILD_TYPE=Coverage $PARENTDIR
   - make
-  - make gtest
   - make coverage
 
 after_success:


### PR DESCRIPTION
Can now install lcov in a non-manual way, which seems simpler and quite possibly more stable.