### PR TITLE
Correct gcov version mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - lcov
             - g++-7
       env:
-        - MATRIX_EVAL="CXX_COMPILER=g++-7"
+        - MATRIX_EVAL="CXX_COMPILER=g++-7; sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 90"
 
     - os: osx
       osx_image: xcode10.1


### PR DESCRIPTION
In the CI build with `g++-7`, it seems that the old version of `gcov` is used. Make sure that the correct version is used, as these kinds of mismatches can crash/corrupt the coverage report generation.