### PR TITLE
Clarify the need to clone submodules before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-        
+      with:
+          submodules: true
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=debug ..
     - name: build
@@ -30,13 +25,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-        
+      with:
+          submodules: true
     - name: configure
       run: |
         mkdir build

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ upload this to Coveralls.io and/or Codecov.io
 When starting a new project, you probably don't want the history of this repository. To start fresh you can use
 the [setup script](setup.sh) as follows:
 ``` bash
-> git clone https://github.com/bsamseth/cpp-project  # Or use ssh-link if you like.
+> git clone --recurse-submodules https://github.com/bsamseth/cpp-project  # Or use ssh-link if you like.
 > cd cpp-project
-> sh setup.sh
+> bash setup.sh
 ```
 The result is a fresh Git repository with one commit adding all files from the boiler plate. 

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Initialize submodules: This should already be done when cloning, but there are ways to muck it
-# up if you do things in the wrong order. So just to be sure, we do it now.
-git submodule update --init --recursive
-
-# Remove the remote (you probably want your own instead).
-git remote remove origin
-
 # Revert to first commit, add and commit everything as single commit.
 git reset "$(git rev-list --max-parents=0 --abbrev-commit HEAD)"
 
@@ -23,3 +16,9 @@ else
 	git commit --amend --author="$name <$email>" 
 fi
 
+# Initialize submodules: This should already be done when cloning, but there are ways to muck it
+# up if you do things in the wrong order. So just to be sure, we do it now.
+git submodule update --init --recursive
+
+# Remove the remote (you probably want your own instead).
+git remote remove origin

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+# Initialize submodules: This should already be done when cloning, but there are ways to muck it
+# up if you do things in the wrong order. So just to be sure, we do it now.
+git submodule update --init --recursive
 
 # Remove the remote (you probably want your own instead).
 git remote remove origin
@@ -19,8 +23,3 @@ else
 	git commit --amend --author="$name <$email>" 
 fi
 
-# Initialize submodules: This is done by CMake, but there are ways to muck it
-# up if you does things in the wrong order. So just to be sure, we do it now.
-git submodule init
-
-git submodule update

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Revert to first commit, add and commit everything as single commit.
-git reset "$(git rev-list --max-parents=0 --abbrev-commit HEAD)"
-
-git add --all
+git reset $(git commit-tree HEAD^{tree} -m "Bolier plate for C++ project added")
 
 name=$(git config user.name)
 email=$(git config user.email)


### PR DESCRIPTION
Issue #21 highlights a potential issue, in that it is not made clear
that you need to pull down the submodules before building. This updates
the README to make this a little more clear.

Also, seems the `setup.sh` script had a potential bug, where the syntax
used is not supported by all versions of sh (double brackets `[[`). So
the default executable is changed to bash, and for good measure the
submodule stuff is done first, just in case.

Closes #21.