### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/bsamseth/cpp-project.svg)](http://isitmaintained.com/project/bsamseth/cpp-project "Percentage of issues still open")
 
 # Boiler plate for C++ projects 
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fbsamseth%2Fcpp-project&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 This is a boiler plate for C++ projects. What you get:
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1642)](https://user-images.githubusercontent.com/47092464/98443204-de89d600-2144-11eb-9adf-cce7c9106060.png)
