### PR TITLE
Updating doctest tag

### DIFF
--- a/cmake/Doctest.cmake
+++ b/cmake/Doctest.cmake
@@ -4,7 +4,7 @@ if(ENABLE_DOCTESTS)
     FetchContent_Declare(
             DocTest
             GIT_REPOSITORY "https://github.com/onqtam/doctest"
-            GIT_TAG "932a2ca50666138256dae56fbb16db3b1cae133a"
+            GIT_TAG "v2.4.8"
     )
 
     FetchContent_MakeAvailable(DocTest)


### PR DESCRIPTION
There is a issue with the current doclib tag and the `glibc-2.34`, as mentioned [here](https://github.com/doctest/doctest/issues/473).

I updated the Doctest to the latest tag.

Before updating:

![test](https://user-images.githubusercontent.com/12504551/149255321-070ee428-81af-464e-8701-fb3446802bdc.png)

```
./build/_deps/doctest-src/doctest/doctest.h:4036:47: error: size of array ‘altStackMem’ is not an integral constant-expression
 4036 |         static char             altStackMem[4 * SIGSTKSZ];
      |                                               ^
make[2]: *** [CMakeFiles/main.dir/build.make:76: CMakeFiles/main.dir/app/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:930: CMakeFiles/main.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

After updating:

![test2](https://user-images.githubusercontent.com/12504551/149255342-650358f7-fc1c-400d-8826-c008c91435bf.png)


```
Consolidate compiler generated dependencies of target engine
[ 16%] Building CXX object CMakeFiles/engine.dir/src/example.cpp.o
[ 16%] Built target engine
Consolidate compiler generated dependencies of target main
[ 33%] Building CXX object CMakeFiles/main.dir/app/main.cpp.o
[ 50%] Linking CXX executable main
[ 50%] Built target main
[ 66%] Building CXX object tests/CMakeFiles/unit_tests.dir/main.cpp.o
[ 83%] Building CXX object tests/CMakeFiles/unit_tests.dir/dummy.cpp.o
[100%] Linking CXX executable ../unit_tests
[100%] Built target unit_tests
```