### PR TITLE
Update doctest tag to fix Windows compilation under C++20.

### DIFF
--- a/cmake/Doctest.cmake
+++ b/cmake/Doctest.cmake
@@ -4,7 +4,7 @@ if(ENABLE_DOCTESTS)
     FetchContent_Declare(
             DocTest
             GIT_REPOSITORY "https://github.com/onqtam/doctest"
-            GIT_TAG "932a2ca50666138256dae56fbb16db3b1cae133a"
+            GIT_TAG "b7c21ec5ceeadb4951b00396fc1e4642dd347e5f"
     )
 
     FetchContent_MakeAvailable(DocTest)


### PR DESCRIPTION
The template fails to compile with projects that use the C++20 flag in MSVC. The emitted error is:

```
doctest-src\doctest/doctest.h(3571,21): error C2039: 'uncaught_exception': is not a member of 'std' 
doctest/doctest.h(3571,15): error C3861: 'uncaught_exception': identifier not found 
...
```

The problem is described in [this issue](https://github.com/doctest/doctest/issues/333) of the doctest repository and fixed in newer versions. This PR updates the doctest tag to use, the currently latest, [version v2.4.9](https://github.com/doctest/doctest/tree/v2.4.9)