### PR TITLE
Allow multiple configurations on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: cmake -S . -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
 
     - name: Build with ${{ matrix.compiler }}
-      run: cmake --build build
+      run: cmake --build build --config ${{ matrix.configuration }}
 
     - name: Test
       working-directory: build


### PR DESCRIPTION
The current CI workflow fails if one attempts to specify any configuration other than `Debug` on Windows. The reason is that windows configuration happens at build time, not cmake generation time, and different output folders are produced (e.g. `build\Debug` and `build\Release`). Since **Debug** is the default configuration, a debug build is always be produced and an example failure would be that of "a test workflow unable to find the release executables". 

Solution is to use the `--config` option on the build command, which works for linux and mac as well. The template could also provide both Debug and Release configurations in the strategy matrix by default, but that depends on the maintainer's intentions.

[source](https://stackoverflow.com/a/20423820)